### PR TITLE
GitHub action release binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build bugout command-line tool
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15.6
+      - name: Build bugout binary
+        run: |
+          go build -o bugout cmd/bugout/main.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build bugout command-line tool
 
-on: [ push ]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+# Inspired heavily by sample action yaml file on:
+# https://github.com/actions/upload-release-asset
+name: Prepare release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+      matrix:
+        os: ["linux"]
+        arch: ["386", "amd64"]
+        # os: ["linux", "darwin", "windows"]
+        # arch: ["386", "amd64", "arm"]
+        # exclude:
+        #   - os: "darwin"
+        #     arch: "arm"
+        #   - os: "windows"
+        #     arch: "arm"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15.6
+      - uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: "Bugout Go client - ${{ github_ref }}"
+          body: |
+            Version ${{ github.ref }} of the Bugout Go client library and command line tool
+          draft: true
+          prerelease: false
+      - name: Build binary for each valid (GOOS, GOARCH) pair
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+        run: |
+          BUILD_DIR="bugout-${GOOS}-${GOARCH}"
+          mkdir "$BUILD_DIR"
+          cp README.md "$BUILD_DIR/README.md"
+          go build -o "$BUILD_DIR/bugout" cmd/bugout/main.go
+          zip -r "$BUILD_DIR.zip" "$BUILD_DIR"
+      - name: Upload release artifacts
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./bugout-${{ matrix.os }}-${{ matrix.arch }}.zip
+          asset_name: bugout-${{ matrix.os }}-${{ matrix.arch }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: "Bugout Go client - ${{ github_ref }}"
+          release_name: "Bugout Go client - ${{ github.ref }}"
           body: |
             Version ${{ github.ref }} of the Bugout Go client library and command line tool
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,25 @@ on:
       - 'v*'
 
 jobs:
-  release:
+  create_release:
     runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: "Bugout Go client - ${{ github.ref }}"
+          body: |
+            Version ${{ github.ref }} of the Bugout Go client library and command line tool
+          draft: true
+          prerelease: false
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+  upload_assets:
+    runs-on: ubuntu-20.04
+    needs: create_release
     strategy:
       fail-fast: true
       matrix:
@@ -27,17 +44,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ^1.15.6
-      - uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: "Bugout Go client - ${{ github.ref }}"
-          body: |
-            Version ${{ github.ref }} of the Bugout Go client library and command line tool
-          draft: true
-          prerelease: false
       - name: Build binary for each valid (GOOS, GOARCH) pair
         env:
           GOOS: ${{ matrix.os }}
@@ -48,12 +54,12 @@ jobs:
           cp README.md "$BUILD_DIR/README.md"
           go build -o "$BUILD_DIR/bugout" cmd/bugout/main.go
           zip -r "$BUILD_DIR.zip" "$BUILD_DIR"
-      - name: Upload release artifacts
+      - name: Upload release asset for each valid (GOOS, GOARH) pair
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: ./bugout-${{ matrix.os }}-${{ matrix.arch }}.zip
           asset_name: bugout-${{ matrix.os }}-${{ matrix.arch }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["linux"]
-        arch: ["386", "amd64"]
-        # os: ["linux", "darwin", "windows"]
-        # arch: ["386", "amd64", "arm"]
-        # exclude:
-        #   - os: "darwin"
-        #     arch: "arm"
-        #   - os: "windows"
-        #     arch: "arm"
+        os: ["linux", "darwin", "windows"]
+        arch: ["386", "amd64", "arm"]
+        exclude:
+          - os: "darwin"
+            arch: "arm"
+          - os: "darwin"
+            arch: "386"
+          - os: "windows"
+            arch: "arm"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2


### PR DESCRIPTION
Introduces the following GitHub Actions:
- Build binary on every pull request (as a sanity check that at least the binaries compile).
- Build binaries for various platforms and create a release with those binaries as release artifacts every time a tag is pushed of the form `v*`.