### PR TITLE
BUGOUT_TIMEOUT_SECONDS environment variable

### DIFF
--- a/pkg/brood/client.go
+++ b/pkg/brood/client.go
@@ -122,13 +122,13 @@ func ClientFromEnv() (BroodClient, error) {
 		broodURL = BugoutBroodURL
 	}
 
-	broodTimeoutSecondsRaw := os.Getenv("BUGOUT_BROOD_TIMEOUT_SECONDS")
+	broodTimeoutSecondsRaw := os.Getenv("BUGOUT_TIMEOUT_SECONDS")
 	if broodTimeoutSecondsRaw == "" {
 		broodTimeoutSecondsRaw = "3"
 	}
 	broodTimeoutSeconds, conversionErr := strconv.Atoi(broodTimeoutSecondsRaw)
 	if conversionErr != nil {
-		return BroodClient{}, fmt.Errorf("Could not parse environment variable as integer: BUGOUT_BROOD_TIMEOUT_SECONDS=%s", broodTimeoutSecondsRaw)
+		return BroodClient{}, fmt.Errorf("Could not parse environment variable as integer: BUGOUT_TIMEOUT_SECONDS=%s", broodTimeoutSecondsRaw)
 	}
 	broodTimeout := time.Duration(broodTimeoutSeconds) * time.Second
 

--- a/pkg/spire/client.go
+++ b/pkg/spire/client.go
@@ -86,7 +86,7 @@ func ClientFromEnv() (SpireClient, error) {
 		spireURL = BugoutSpireURL
 	}
 
-	spireTimeoutSecondsRaw := os.Getenv("BUGOUT_SPIRE_TIMEOUT_SECONDS")
+	spireTimeoutSecondsRaw := os.Getenv("BUGOUT_TIMEOUT_SECONDS")
 	if spireTimeoutSecondsRaw == "" {
 		spireTimeoutSecondsRaw = "3"
 	}

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,3 +1,3 @@
 package bugout
 
-const Version string = "0.1.0"
+const Version string = "0.2.0"


### PR DESCRIPTION
Replaces and consolidates `BUGOUT_BROOD_TIMEOUT_SECONDS` and `BUGOUT_SPIRE_TIMEOUT_SECONDS`.