### PR TITLE
Updated "bugout trap" to respect stdin

### DIFF
--- a/cmd/bugout/cmdutils/config.go
+++ b/cmd/bugout/cmdutils/config.go
@@ -74,3 +74,12 @@ func CompositePopulator(populators ...cobra.PositionalArgs) cobra.PositionalArgs
 		return nil
 	}
 }
+
+func BugoutURL() string {
+	defaultBugoutURL := "https://bugout.dev"
+	bugoutURL := os.Getenv("BUGOUT_URL")
+	if bugoutURL == "" {
+		bugoutURL = defaultBugoutURL
+	}
+	return bugoutURL
+}

--- a/cmd/bugout/trap/command.go
+++ b/cmd/bugout/trap/command.go
@@ -1,8 +1,8 @@
 package trapcmd
 
 import (
-	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -40,7 +40,7 @@ Specify the wrapped command using "--" followed by the command:
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			result, err := RunWrappedCommand(args)
+			result, err := RunWrappedCommand(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -57,8 +57,8 @@ Specify the wrapped command using "--" followed by the command:
 				return err
 			}
 
-			encodeErr := json.NewEncoder(cmd.OutOrStdout()).Encode(response)
-			return encodeErr
+			cmd.ErrOrStderr().Write([]byte(fmt.Sprintf("\n\nBugout entry created at: %s/journals/%s/%s\n", cmdutils.BugoutURL(), journalID, response.Id)))
+			return nil
 		},
 	}
 

--- a/cmd/bugout/trap/render.go
+++ b/cmd/bugout/trap/render.go
@@ -17,21 +17,21 @@ type TrapEntry struct {
 	Context spire.EntryContext
 }
 
-func Render(invocation []string, result InvocationResult, title string, tags []string, showEnv bool) TrapEntry {
+func Render(invocation []string, result *InvocationResult, title string, tags []string, showEnv bool) TrapEntry {
 	renderedTitle := RenderTitle(invocation, result, title, tags, showEnv)
 	renderedTags := RenderTags(invocation, result, title, tags, showEnv)
 	renderedContent := RenderContent(invocation, result, title, tags, showEnv)
 	return TrapEntry{Title: renderedTitle, Content: renderedContent, Tags: renderedTags, Context: spire.EntryContext{ContextType: "trap"}}
 }
 
-func RenderTitle(invocation []string, result InvocationResult, title string, tags []string, showEnv bool) string {
+func RenderTitle(invocation []string, result *InvocationResult, title string, tags []string, showEnv bool) string {
 	if title != "" {
 		return title
 	}
 	return fmt.Sprintf("Command: %s (exited with code %d)", invocation[0], result.ExitCode)
 }
 
-func RenderTags(invocation []string, result InvocationResult, title string, tags []string, showEnv bool) []string {
+func RenderTags(invocation []string, result *InvocationResult, title string, tags []string, showEnv bool) []string {
 	trapTags := []string{
 		"trap",
 		"cli",
@@ -43,7 +43,7 @@ func RenderTags(invocation []string, result InvocationResult, title string, tags
 	return finalTags
 }
 
-func RenderContent(invocation []string, result InvocationResult, title string, tags []string, showEnv bool) string {
+func RenderContent(invocation []string, result *InvocationResult, title string, tags []string, showEnv bool) string {
 	quotedInvocation := make([]string, len(invocation))
 	for i, component := range invocation {
 		quotedInvocation[i] = strconv.Quote(component)
@@ -59,8 +59,8 @@ func RenderContent(invocation []string, result InvocationResult, title string, t
 	var content string = strings.Join([]string{
 		fmt.Sprintf("## invocation\n```\n%s\n```\n", strings.Join(quotedInvocation, " ")),
 		fmt.Sprintf("## exit code\n`%d`\n", result.ExitCode),
-		fmt.Sprintf("## stdout\n```\n%s\n```\n", result.OutBuffer.String()),
-		fmt.Sprintf("## stderr\n```\n%s\n```\n", result.ErrBuffer.String()),
+		fmt.Sprintf("## stdout\n```\n%s\n```\n", result.Stdout),
+		fmt.Sprintf("## stderr\n```\n%s\n```\n", result.Stderr),
 	}, "\n")
 
 	if showEnv {

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,3 +1,3 @@
 package bugout
 
-const Version string = "0.2.0"
+const Version string = "0.3.0"


### PR DESCRIPTION
This means you can even use it for interactive commands (like `less`,
`top`, etc.).

`bugout trap` now streams its wrapped command's stdout and stderr to its
own stdout and stderr. It functions more like `time` now.