### PR TITLE
bugout trap now respects SIGINT

### DIFF
--- a/cmd/bugout/trap/command.go
+++ b/cmd/bugout/trap/command.go
@@ -3,6 +3,7 @@ package trapcmd
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -58,6 +59,10 @@ Specify the wrapped command using "--" followed by the command:
 			}
 
 			cmd.ErrOrStderr().Write([]byte(fmt.Sprintf("\n\nBugout entry created at: %s/journals/%s/%s\n", cmdutils.BugoutURL(), journalID, response.Id)))
+
+			if result.ExitCode > 0 {
+				os.Exit(result.ExitCode)
+			}
 			return nil
 		},
 	}

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,3 +1,3 @@
 package bugout
 
-const Version string = "0.3.0"
+const Version string = "0.3.1"


### PR DESCRIPTION
Before, if you wrapped a long-running command with `bugout trap --`, and
then interrupted the execution of the command, `bugout trap` would not
create a journal entry because it would get interrupted as well.

The new behavior is that `bugout trap` creates a journal entry if
possible after interruption.

Also fixed a bug with process exit codes - `bugout trap` now returns
non-zero exit codes returned from its wrapped commands.