### PR TITLE
Some bugfixes for "bugout trap"

### DIFF
--- a/cmd/bugout/trap/invoke.go
+++ b/cmd/bugout/trap/invoke.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,7 @@ type InvocationResult struct {
 }
 
 func stream(reader io.Reader, writer io.Writer, doneChan chan<- bool, cancelChan <-chan bool) {
-	b := make([]byte, 1)
+	b := make([]byte, 1024)
 	for {
 		select {
 		case <-cancelChan:
@@ -97,6 +98,8 @@ func RunWrappedCommand(trapCmd *cobra.Command, invocation []string) (*Invocation
 						exitChannel <- 1
 					}
 					return
+				} else {
+					time.Sleep(10 * time.Millisecond)
 				}
 			}
 		}

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,3 +1,3 @@
 package bugout
 
-const Version string = "0.3.1"
+const Version string = "0.3.2"


### PR DESCRIPTION
- Added a sleep to the controller goroutine. Without this, `bugout trap` was saturating a whole CPU core.
- Increased buffer size to 1 kib for stream goroutines. Without this, stdout and stderr were getting eaten up on exit. This is a quick fix.