### PR TITLE
Support both cases for resource holder id

### DIFF
--- a/pkg/brood/data.go
+++ b/pkg/brood/data.go
@@ -1,5 +1,9 @@
 package brood
 
+import (
+	"encoding/json"
+)
+
 type User struct {
 	Id              string `json:"id"`
 	Username        string `json:"username"`
@@ -83,9 +87,35 @@ type resourceUpdateRequest struct {
 }
 
 type ResourceHolder struct {
-	Id          string   `json:"id"`
+	Id          string   `json:"holder_id"`
 	HolderType  string   `json:"holder_type"`
 	Permissions []string `json:"permissions"`
+}
+
+func (r *ResourceHolder) UnmarshalJSON(data []byte) error {
+	// Define an alias to avoid recursion in custom unmarshaling
+	type Alias ResourceHolder
+	aux := &struct {
+		Id       string `json:"id"`
+		HolderId string `json:"holder_id"`
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	}
+
+	// Unmarshal into the auxiliary struct
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// Populate the Id field based on available data
+	if aux.Id != "" {
+		r.Id = aux.Id
+	} else {
+		r.Id = aux.HolderId
+	}
+
+	return nil
 }
 
 type ResourceHolders struct {

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,3 +1,3 @@
 package bugout
 
-const Version string = "0.4.5"
+const Version string = "0.4.6"


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Since creation uses `holder_id` but response returns just `id` we need to support both cases.

## How to test these changes?

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
